### PR TITLE
Add some metadata to the desktop entry

### DIFF
--- a/snap/gui/standup-timer.desktop
+++ b/snap/gui/standup-timer.desktop
@@ -1,6 +1,8 @@
 [Desktop Entry]
 Name=Stand-Up Timer
+GenericName=Timer
 Comment=A lightweight app to help run stand-up meetings
+Keywords=standup-timer;standup;stand-up;scrum;daily-scrum;
 Exec=standup-timer
 Type=Application
 Categories=Office;ProjectManagement;Clock;


### PR DESCRIPTION
This adds a `GenericName` and some common keywords to the desktop entry.

This should make searching for the application a better experience, as words such as `standup` or `scrum` should now bring up the application.