### PR TITLE
chore(deps): remove unused cupertino_icons

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,14 +113,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.8"
   dbus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,16 +30,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  circular_countdown_timer: ^0.2.0 # Or the latest version
+  circular_countdown_timer: ^0.2.0
   http: ^1.3.0
   desktop_window: ^0.4.2
   yaru: ^8.0.0
   yaru_window: ^0.2.1
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.6
-
   window_size: ^0.1.0
   clipboard: ^0.1.3
   shared_preferences: ^2.2.2


### PR DESCRIPTION
`cupertino_icons` is not used. We are not packaging the application with iOS style icons