### PR TITLE
[New] add CI dashboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,59 @@ On snap-ready systems, you can install it on the command-line with:
 sudo snap install standup-timer
 ```
 
+## CI/CD Dashboard
+
+Stand-Up Timer can display the status of CI/CD workflows during the meeting.
+Configure it by creating `~/.config/standup-timer/workflows.yaml`.
+
+### GitHub Actions
+
+```yaml
+github_token: ghp_xxxx          # optional default token for all GitHub entries
+
+workflows:
+  - label: "My workflow"        # display name (optional)
+    provider: github
+    owner: canonical             # GitHub organisation or user
+    repo: my-repo
+    workflow: ci.yaml            # workflow filename
+    token: ghp_xxxx              # per-entry token (overrides github_token)
+```
+
+The `token` is only required for private repositories. It can be set once as
+`github_token` at the top level and will apply to all GitHub entries that do
+not specify their own `token`.
+
+### Jenkins
+
+```yaml
+workflows:
+  - label: "My Jenkins job"     # display name (optional)
+    provider: jenkins
+    url: https://jenkins.example.com/job/my-job
+    username: admin              # optional
+    token: abc123                # Jenkins API token (optional)
+```
+
+### Mixed example
+
+```yaml
+github_token: ghp_xxxx
+
+workflows:
+  - label: "Checkbox Daily Builds"
+    provider: github
+    owner: canonical
+    repo: checkbox
+    workflow: checkbox-daily-native-builds.yaml
+
+  - label: "Release pipeline"
+    provider: jenkins
+    url: https://jenkins.example.com/job/release
+    username: admin
+    token: abc123
+```
+
 ## Community and Support
 
 You can report any issues, bugs, or feature requests on the project's

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ sudo snap install standup-timer
 ## CI/CD Dashboard
 
 Stand-Up Timer can display the status of CI/CD workflows during the meeting.
-Configure it by creating `~/.config/standup-timer/workflows.yaml`.
+Configure it by creating `~/.config/standup-timer/workflows.yaml` or in 
+`~/snap/standup-timer/current/.config/standup-timer/workflows.yaml` if
+running from snap.
 
 ### GitHub Actions
 

--- a/lib/comic.dart
+++ b/lib/comic.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
-import 'widgets/timer_controls.dart';
 
 class Comic {
   final String title;
@@ -55,19 +54,11 @@ Future<Comic> fetchComic() async {
 }
 
 class ComicScreen extends StatefulWidget {
-  final bool showTimerControls;
-  final bool isRunning;
-  final bool isDisabled;
-  final VoidCallback? onToggleTimer;
-  final VoidCallback? onResetTimer;
+  final VoidCallback? onNext;
 
   const ComicScreen({
     super.key,
-    this.showTimerControls = false,
-    this.isRunning = false,
-    this.isDisabled = false,
-    this.onToggleTimer,
-    this.onResetTimer,
+    this.onNext,
   });
 
   @override
@@ -200,7 +191,7 @@ class _ComicScreenState extends State<ComicScreen> {
                       Expanded(
                         child: Container(
                           width: constraints.maxWidth,
-                          height: constraints.maxHeight - (widget.showTimerControls ? 180 : 120), // Reserve space for controls if needed
+                          height: constraints.maxHeight - (widget.onNext != null ? 180 : 120),
                           padding: const EdgeInsets.symmetric(horizontal: 16),
                           child: GestureDetector(
                             onTap: () => _showImageModal(context, comic),
@@ -210,7 +201,7 @@ class _ComicScreenState extends State<ComicScreen> {
                                 comic.img,
                                 fit: BoxFit.contain,
                                 width: constraints.maxWidth - 32,
-                                height: constraints.maxHeight - (widget.showTimerControls ? 180 : 120),
+                                height: constraints.maxHeight - (widget.onNext != null ? 180 : 120),
                                 loadingBuilder: (context, child, progress) {
                                   if (progress == null) return child;
                                   return const Center(child: CircularProgressIndicator());
@@ -232,14 +223,16 @@ class _ComicScreenState extends State<ComicScreen> {
                           textAlign: TextAlign.center,
                         ),
                       ),
-                      if (widget.showTimerControls) ...[
+                      if (widget.onNext != null) ...[
                         Padding(
                           padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                          child: TimerControls(
-                            isRunning: widget.isRunning,
-                            isDisabled: widget.isDisabled,
-                            onToggleTimer: widget.onToggleTimer ?? () {},
-                            onResetTimer: widget.onResetTimer ?? () {},
+                          child: Align(
+                            alignment: Alignment.centerRight,
+                            child: OutlinedButton.icon(
+                              onPressed: widget.onNext,
+                              icon: const Icon(Icons.dashboard_outlined, size: 16),
+                              label: const Text('View CI Dashboard'),
+                            ),
                           ),
                         ),
                       ],

--- a/lib/providers/workflows_provider.dart
+++ b/lib/providers/workflows_provider.dart
@@ -54,8 +54,7 @@ class WorkflowsNotifier extends Notifier<WorkflowsState> {
 
     if (_providers == null) {
       state = const WorkflowsState(
-        configError:
-            'Create ~/.config/standup-timer/workflows.yaml to monitor CI workflows.',
+        configError: 'Create workflows.yaml to monitor CI workflows.',
       );
       return;
     }
@@ -68,7 +67,8 @@ class WorkflowsNotifier extends Notifier<WorkflowsState> {
     }
 
     refresh();
-    _refreshTimer = Timer.periodic(const Duration(seconds: 60), (_) => refresh());
+    _refreshTimer =
+        Timer.periodic(const Duration(seconds: 60), (_) => refresh());
   }
 
   Future<void> refresh() async {

--- a/lib/providers/workflows_provider.dart
+++ b/lib/providers/workflows_provider.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../services/ci_provider.dart';
+import '../services/config_service.dart';
+
+class WorkflowsState {
+  final List<CiRun> runs;
+  final bool isLoading;
+  final String? configError;
+  final DateTime? lastFetched;
+
+  const WorkflowsState({
+    this.runs = const [],
+    this.isLoading = false,
+    this.configError,
+    this.lastFetched,
+  });
+
+  WorkflowsState copyWith({
+    List<CiRun>? runs,
+    bool? isLoading,
+    String? configError,
+    DateTime? lastFetched,
+  }) {
+    return WorkflowsState(
+      runs: runs ?? this.runs,
+      isLoading: isLoading ?? this.isLoading,
+      configError: configError ?? this.configError,
+      lastFetched: lastFetched ?? this.lastFetched,
+    );
+  }
+}
+
+class WorkflowsNotifier extends Notifier<WorkflowsState> {
+  Timer? _refreshTimer;
+  List<CiProvider>? _providers;
+
+  @override
+  WorkflowsState build() {
+    ref.onDispose(() => _refreshTimer?.cancel());
+    // Schedule _init after build() returns so that `state` is initialized
+    // before refresh() tries to read it.
+    Future.microtask(_init);
+    return const WorkflowsState(isLoading: true);
+  }
+
+  void _init() {
+    try {
+      _providers = ConfigService.loadProviders();
+    } catch (e) {
+      state = WorkflowsState(configError: 'Failed to parse config: $e');
+      return;
+    }
+
+    if (_providers == null) {
+      state = const WorkflowsState(
+        configError:
+            'Create ~/.config/standup-timer/workflows.yaml to monitor CI workflows.',
+      );
+      return;
+    }
+
+    if (_providers!.isEmpty) {
+      state = const WorkflowsState(
+        configError: 'No workflows listed in workflows.yaml.',
+      );
+      return;
+    }
+
+    refresh();
+    _refreshTimer = Timer.periodic(const Duration(seconds: 60), (_) => refresh());
+  }
+
+  Future<void> refresh() async {
+    if (_providers == null) return;
+    state = state.copyWith(isLoading: true);
+
+    final runs = await Future.wait(
+      _providers!.map((p) => p.fetchLatestRun()),
+    );
+
+    state = state.copyWith(
+      runs: runs,
+      isLoading: false,
+      lastFetched: DateTime.now(),
+    );
+  }
+}
+
+final workflowsProvider =
+    NotifierProvider<WorkflowsNotifier, WorkflowsState>(WorkflowsNotifier.new);

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,336 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../providers/workflows_provider.dart';
+import '../services/ci_provider.dart';
+import '../services/config_service.dart';
+import '../widgets/timer_controls.dart';
+
+class DashboardScreen extends ConsumerWidget {
+  final bool showTimerControls;
+  final bool isRunning;
+  final bool isDisabled;
+  final VoidCallback? onToggleTimer;
+  final VoidCallback? onResetTimer;
+
+  const DashboardScreen({
+    super.key,
+    this.showTimerControls = false,
+    this.isRunning = false,
+    this.isDisabled = false,
+    this.onToggleTimer,
+    this.onResetTimer,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(workflowsProvider);
+    final theme = Theme.of(context);
+
+    return Column(
+      children: [
+        _Header(
+          state: state,
+          onRefresh: () => ref.read(workflowsProvider.notifier).refresh(),
+        ),
+        Divider(height: 1, color: theme.colorScheme.outlineVariant),
+        Expanded(child: _Body(state: state)),
+        if (showTimerControls) ...[
+          Divider(height: 1, color: theme.colorScheme.outlineVariant),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+            child: TimerControls(
+              isRunning: isRunning,
+              isDisabled: isDisabled,
+              onToggleTimer: onToggleTimer ?? () {},
+              onResetTimer: onResetTimer ?? () {},
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+// ── Header ────────────────────────────────────────────────────────────────────
+
+class _Header extends StatelessWidget {
+  final WorkflowsState state;
+  final VoidCallback onRefresh;
+
+  const _Header({required this.state, required this.onRefresh});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 10, 8, 10),
+      child: Row(
+        children: [
+          Icon(Icons.check_circle_outline, size: 18, color: theme.colorScheme.primary),
+          const SizedBox(width: 8),
+          Text('CI Status', style: theme.textTheme.titleSmall),
+          const Spacer(),
+          if (state.lastFetched != null)
+            Text(
+              _timeAgo(state.lastFetched!),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          const SizedBox(width: 4),
+          SizedBox(
+            width: 36,
+            height: 36,
+            child: state.isLoading
+                ? const Padding(
+                    padding: EdgeInsets.all(10),
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : IconButton(
+                    icon: const Icon(Icons.refresh, size: 18),
+                    tooltip: 'Refresh',
+                    onPressed: onRefresh,
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Body ──────────────────────────────────────────────────────────────────────
+
+class _Body extends StatelessWidget {
+  final WorkflowsState state;
+
+  const _Body({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    if (state.configError != null) {
+      return _EmptyState(
+        icon: Icons.settings_outlined,
+        message: state.configError!,
+        hint: '# ${ConfigService.configPath}\n\n'
+            '# github_token: ghp_xxxx  # default token for all GitHub entries\n\n'
+            'workflows:\n'
+            '  - label: "Checkbox Daily Builds"\n'
+            '    provider: github\n'
+            '    owner: canonical\n'
+            '    repo: checkbox\n'
+            '    workflow: checkbox-daily-native-builds.yaml\n\n'
+            '  - label: "My Jenkins job"\n'
+            '    provider: jenkins\n'
+            '    url: https://jenkins.example.com/job/my-job\n'
+            '    # username: admin\n'
+            '    # token: abc123',
+      );
+    }
+
+    if (state.isLoading && state.runs.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      itemCount: state.runs.length,
+      separatorBuilder: (_, __) => Divider(
+        height: 1,
+        indent: 16,
+        endIndent: 16,
+        color: theme.colorScheme.outlineVariant,
+      ),
+      itemBuilder: (context, i) => _RunRow(run: state.runs[i]),
+    );
+  }
+}
+
+// ── Empty / error state ───────────────────────────────────────────────────────
+
+class _EmptyState extends StatelessWidget {
+  final IconData icon;
+  final String message;
+  final String? hint;
+
+  const _EmptyState({
+    required this.icon,
+    required this.message,
+    this.hint,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 40, color: theme.colorScheme.onSurfaceVariant),
+            const SizedBox(height: 12),
+            Text(message, textAlign: TextAlign.center, style: theme.textTheme.bodyMedium),
+            if (hint != null) ...[
+              const SizedBox(height: 16),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: SelectableText(
+                  hint!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontFamily: 'monospace',
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Single row ────────────────────────────────────────────────────────────────
+
+class _RunRow extends StatelessWidget {
+  final CiRun run;
+
+  const _RunRow({required this.run});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (color, icon, badgeLabel) = _statusStyle(run.status, theme);
+    final canOpen = run.runUrl != null;
+
+    return Tooltip(
+      message: run.fetchError ?? '',
+      child: InkWell(
+        onTap: canOpen
+            ? () => launchUrl(
+                  Uri.parse(run.runUrl!),
+                  mode: LaunchMode.externalApplication,
+                )
+            : null,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          child: Row(
+            children: [
+              // Status dot
+              Container(
+                width: 10,
+                height: 10,
+                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+              ),
+              const SizedBox(width: 12),
+
+              // Label + branch/repo
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      run.label,
+                      style: theme.textTheme.bodyMedium,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (run.fetchError != null)
+                      Text(
+                        run.fetchError!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.error,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      )
+                    else if (run.branch != null)
+                      Text(
+                        run.branch!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                  ],
+                ),
+              ),
+
+              const SizedBox(width: 8),
+
+              // Time ago
+              if (run.updatedAt != null)
+                Text(
+                  _timeAgo(run.updatedAt!),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+
+              const SizedBox(width: 8),
+
+              // Status badge
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                decoration: BoxDecoration(
+                  color: color.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(10),
+                  border: Border.all(color: color.withValues(alpha: 0.4)),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(icon, size: 12, color: color),
+                    const SizedBox(width: 4),
+                    Text(
+                      badgeLabel,
+                      style: theme.textTheme.labelSmall?.copyWith(color: color),
+                    ),
+                  ],
+                ),
+              ),
+
+              if (canOpen) ...[
+                const SizedBox(width: 4),
+                Icon(Icons.open_in_new, size: 14, color: theme.colorScheme.onSurfaceVariant),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static (Color, IconData, String) _statusStyle(String status, ThemeData theme) {
+    return switch (status) {
+      'success'         => (const Color(0xFF2DA44E), Icons.check_circle_outline, 'success'),
+      'failure'         => (const Color(0xFFCF222E), Icons.cancel_outlined, 'failure'),
+      'in_progress'     => (const Color(0xFF0969DA), Icons.sync, 'running'),
+      'queued'          => (const Color(0xFFBF8700), Icons.schedule, 'queued'),
+      'cancelled'       => (const Color(0xFF6E7781), Icons.block, 'cancelled'),
+      'skipped'         => (const Color(0xFF6E7781), Icons.skip_next, 'skipped'),
+      'timed_out'       => (const Color(0xFFBC4C00), Icons.timer_off, 'timed out'),
+      'action_required' => (const Color(0xFFBF8700), Icons.warning_amber, 'needs action'),
+      'error'           => (const Color(0xFFCF222E), Icons.error_outline, 'error'),
+      _                 => (theme.colorScheme.onSurfaceVariant, Icons.help_outline, status),
+    };
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+String _timeAgo(DateTime time) {
+  final diff = DateTime.now().difference(time);
+  if (diff.inSeconds < 60) return 'just now';
+  if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+  if (diff.inHours < 24) return '${diff.inHours}h ago';
+  return '${diff.inDays}d ago';
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -211,10 +211,30 @@ class _RunRow extends StatelessWidget {
       message: run.fetchError ?? '',
       child: InkWell(
         onTap: canOpen
-            ? () => launchUrl(
-                  Uri.parse(run.runUrl!),
-                  mode: LaunchMode.externalApplication,
-                )
+            ? () async {
+                try {
+                  final uri = Uri.parse(run.runUrl!);
+                  final success = await launchUrl(
+                    uri,
+                    mode: LaunchMode.externalApplication,
+                  );
+                  if (!success && context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Could not open the run URL.'),
+                      ),
+                    );
+                  }
+                } catch (_) {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('An error occurred while opening the run URL.'),
+                      ),
+                    );
+                  }
+                }
+              }
             : null,
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -4,22 +4,15 @@ import 'package:url_launcher/url_launcher.dart';
 import '../providers/workflows_provider.dart';
 import '../services/ci_provider.dart';
 import '../services/config_service.dart';
-import '../widgets/timer_controls.dart';
 
 class DashboardScreen extends ConsumerWidget {
-  final bool showTimerControls;
-  final bool isRunning;
+  final VoidCallback? onStartStandup;
   final bool isDisabled;
-  final VoidCallback? onToggleTimer;
-  final VoidCallback? onResetTimer;
 
   const DashboardScreen({
     super.key,
-    this.showTimerControls = false,
-    this.isRunning = false,
+    this.onStartStandup,
     this.isDisabled = false,
-    this.onToggleTimer,
-    this.onResetTimer,
   });
 
   @override
@@ -35,15 +28,17 @@ class DashboardScreen extends ConsumerWidget {
         ),
         Divider(height: 1, color: theme.colorScheme.outlineVariant),
         Expanded(child: _Body(state: state)),
-        if (showTimerControls) ...[
+        if (onStartStandup != null) ...[
           Divider(height: 1, color: theme.colorScheme.outlineVariant),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-            child: TimerControls(
-              isRunning: isRunning,
-              isDisabled: isDisabled,
-              onToggleTimer: onToggleTimer ?? () {},
-              onResetTimer: onResetTimer ?? () {},
+            child: SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: isDisabled ? null : onStartStandup,
+                icon: const Icon(Icons.play_arrow),
+                label: const Text('Start Standup'),
+              ),
             ),
           ),
         ],

--- a/lib/services/ci_provider.dart
+++ b/lib/services/ci_provider.dart
@@ -1,0 +1,27 @@
+/// A provider-agnostic model for a single CI job's latest run result.
+class CiRun {
+  final String label;
+  final String status; // 'success' | 'failure' | 'in_progress' | 'queued' |
+  //                      'cancelled' | 'skipped' | 'timed_out' |
+  //                      'action_required' | 'unknown' | 'error'
+  final String? branch;
+  final DateTime? updatedAt;
+  final String? runUrl;
+  final String? fetchError;
+
+  const CiRun({
+    required this.label,
+    required this.status,
+    this.branch,
+    this.updatedAt,
+    this.runUrl,
+    this.fetchError,
+  });
+}
+
+/// Base class for any CI/CD provider.
+/// Each configured workflow entry is backed by one [CiProvider] instance.
+abstract class CiProvider {
+  String get label;
+  Future<CiRun> fetchLatestRun();
+}

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -30,7 +30,12 @@ import 'jenkins_provider.dart';
 /// ```
 class ConfigService {
   static String get configPath {
-    final home = Platform.environment['HOME'] ?? '';
+    // When running as a Snap, HOME points to the snap's private directory.
+    // SNAP_REAL_HOME contains the actual user home directory.
+    final home =
+        Platform.environment['SNAP_REAL_HOME'] ??
+        Platform.environment['HOME'] ??
+        '';
     return '$home/.config/standup-timer/workflows.yaml';
   }
 

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -30,12 +30,7 @@ import 'jenkins_provider.dart';
 /// ```
 class ConfigService {
   static String get configPath {
-    // When running as a Snap, HOME points to the snap's private directory.
-    // SNAP_REAL_HOME contains the actual user home directory.
-    final home =
-        Platform.environment['SNAP_REAL_HOME'] ??
-        Platform.environment['HOME'] ??
-        '';
+    final home = Platform.environment['HOME'] ?? '';
     return '$home/.config/standup-timer/workflows.yaml';
   }
 

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -1,0 +1,77 @@
+import 'dart:developer' as dev;
+import 'dart:io';
+import 'package:yaml/yaml.dart';
+import 'ci_provider.dart';
+import 'github_provider.dart';
+import 'jenkins_provider.dart';
+
+/// Reads ~/.config/standup-timer/workflows.yaml and returns one [CiProvider]
+/// per configured workflow entry.
+///
+/// Returns null if the config file does not exist.
+/// Throws if the file exists but cannot be parsed.
+///
+/// Example config:
+///
+/// ```yaml
+/// workflows:
+///   - label: "Checkbox Daily Builds"
+///     provider: github
+///     owner: canonical
+///     repo: checkbox
+///     workflow: checkbox-daily-native-builds.yaml
+///     token: ghp_xxxx         # optional; required for private repos
+///
+///   - label: "My Jenkins job"
+///     provider: jenkins
+///     url: https://jenkins.example.com/job/my-job
+///     username: admin          # optional
+///     token: abc123            # Jenkins API token
+/// ```
+class ConfigService {
+  static String get configPath {
+    final home = Platform.environment['HOME'] ?? '';
+    return '$home/.config/standup-timer/workflows.yaml';
+  }
+
+  static List<CiProvider>? loadProviders() {
+    final file = File(configPath);
+    if (!file.existsSync()) return null;
+
+    final doc = loadYaml(file.readAsStringSync());
+    final rawList = doc['workflows'] as YamlList? ?? YamlList.wrap([]);
+
+    // Top-level token acts as a default for all GitHub entries that don't
+    // specify their own token.
+    final defaultGitHubToken = doc['github_token'] as String?;
+    dev.log('[config] github_token present: ${defaultGitHubToken != null}', name: 'ci');
+    dev.log('[config] loaded ${rawList.length} workflow(s)', name: 'ci');
+
+    return rawList.map<CiProvider>((entry) {
+      final provider = entry['provider'] as String? ?? 'github';
+      final label = entry['label'] as String?;
+
+      return switch (provider) {
+        'github' => () {
+            final tok = (entry['token'] as String?) ?? defaultGitHubToken;
+            dev.log('[config] github entry "${label ?? entry['owner']}/${entry['repo']}" token: ${tok != null ? "set" : "NOT SET"}', name: 'ci');
+            return GitHubProvider(
+              label: label ?? '${entry['owner']}/${entry['repo']}',
+              owner: entry['owner'] as String,
+              repo: entry['repo'] as String,
+              workflow: entry['workflow'] as String,
+              // Per-entry token takes priority over the top-level default.
+              token: tok,
+            );
+          }(),
+        'jenkins' => JenkinsProvider(
+            label: label ?? (entry['url'] as String),
+            jobUrl: entry['url'] as String,
+            username: entry['username'] as String?,
+            token: entry['token'] as String?,
+          ),
+        _ => throw FormatException('Unknown provider "$provider"'),
+      };
+    }).toList();
+  }
+}

--- a/lib/services/config_service.dart
+++ b/lib/services/config_service.dart
@@ -37,8 +37,13 @@ class ConfigService {
   static List<CiProvider>? loadProviders() {
     final file = File(configPath);
     if (!file.existsSync()) return null;
+    return parseProviders(file.readAsStringSync());
+  }
 
-    final doc = loadYaml(file.readAsStringSync());
+  /// Parses [yamlContent] and returns one [CiProvider] per configured workflow
+  /// entry. Exposed for testing without touching the filesystem.
+  static List<CiProvider> parseProviders(String yamlContent) {
+    final doc = loadYaml(yamlContent);
     final rawList = doc['workflows'] as YamlList? ?? YamlList.wrap([]);
 
     // Top-level token acts as a default for all GitHub entries that don't

--- a/lib/services/github_provider.dart
+++ b/lib/services/github_provider.dart
@@ -43,7 +43,7 @@ class GitHubProvider implements CiProvider {
     }
 
     dev.log('[github] GET $url', name: 'ci');
-    dev.log('[github] auth: ${token != null ? "Bearer ${token!.substring(0, token!.length.clamp(0, 8))}..." : "none"}', name: 'ci');
+    dev.log('[github] auth: ${token != null && token!.isNotEmpty ? "present" : "none"}', name: 'ci');
 
     try {
       final response = await http

--- a/lib/services/github_provider.dart
+++ b/lib/services/github_provider.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:developer' as dev;
+import 'package:http/http.dart' as http;
+import 'ci_provider.dart';
+
+/// Fetches the latest run for a GitHub Actions workflow.
+///
+/// Config keys (from workflows.yaml):
+///   provider: github
+///   label:    "My workflow"         # display name (optional, defaults to owner/repo)
+///   owner:    canonical
+///   repo:     checkbox
+///   workflow: checkbox-daily-native-builds.yaml   # filename or numeric id
+///   token:    ghp_xxxx             # optional; required for private repos
+class GitHubProvider implements CiProvider {
+  @override
+  final String label;
+  final String owner;
+  final String repo;
+  final String workflow;
+  final String? token;
+
+  const GitHubProvider({
+    required this.label,
+    required this.owner,
+    required this.repo,
+    required this.workflow,
+    this.token,
+  });
+
+  @override
+  Future<CiRun> fetchLatestRun() async {
+    final url =
+        'https://api.github.com/repos/$owner/$repo'
+        '/actions/workflows/$workflow/runs?per_page=1';
+
+    final headers = <String, String>{
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+    if (token != null && token!.isNotEmpty) {
+      headers['Authorization'] = 'Bearer $token';
+    }
+
+    dev.log('[github] GET $url', name: 'ci');
+    dev.log('[github] auth: ${token != null ? "Bearer ${token!.substring(0, token!.length.clamp(0, 8))}..." : "none"}', name: 'ci');
+
+    try {
+      final response = await http
+          .get(Uri.parse(url), headers: headers)
+          .timeout(const Duration(seconds: 15));
+
+      dev.log('[github] ${response.statusCode} for $label', name: 'ci');
+      if (response.statusCode != 200) {
+        dev.log('[github] body: ${response.body}', name: 'ci');
+        return CiRun(
+          label: label,
+          status: 'error',
+          fetchError: 'HTTP ${response.statusCode}',
+        );
+      }
+
+      final data = json.decode(response.body) as Map<String, dynamic>;
+      final runs = data['workflow_runs'] as List?;
+      if (runs == null || runs.isEmpty) {
+        return CiRun(label: label, status: 'unknown');
+      }
+
+      final run = runs[0] as Map<String, dynamic>;
+      final apiStatus = run['status'] as String?;
+      final conclusion = run['conclusion'] as String?;
+
+      final String status;
+      if (apiStatus == 'completed') {
+        status = conclusion ?? 'unknown';
+      } else {
+        status = apiStatus ?? 'unknown';
+      }
+
+      DateTime? updatedAt;
+      final updatedAtStr = run['updated_at'] as String?;
+      if (updatedAtStr != null) updatedAt = DateTime.tryParse(updatedAtStr);
+
+      return CiRun(
+        label: label,
+        status: status,
+        branch: run['head_branch'] as String?,
+        updatedAt: updatedAt,
+        runUrl: run['html_url'] as String?,
+      );
+    } catch (e) {
+      return CiRun(label: label, status: 'error', fetchError: e.toString());
+    }
+  }
+}

--- a/lib/services/github_provider.dart
+++ b/lib/services/github_provider.dart
@@ -19,14 +19,16 @@ class GitHubProvider implements CiProvider {
   final String repo;
   final String workflow;
   final String? token;
+  final http.Client _client;
 
-  const GitHubProvider({
+  GitHubProvider({
     required this.label,
     required this.owner,
     required this.repo,
     required this.workflow,
     this.token,
-  });
+    http.Client? client,
+  }) : _client = client ?? http.Client();
 
   @override
   Future<CiRun> fetchLatestRun() async {
@@ -46,7 +48,7 @@ class GitHubProvider implements CiProvider {
     dev.log('[github] auth: ${token != null && token!.isNotEmpty ? "present" : "none"}', name: 'ci');
 
     try {
-      final response = await http
+      final response = await _client
           .get(Uri.parse(url), headers: headers)
           .timeout(const Duration(seconds: 15));
 

--- a/lib/services/jenkins_provider.dart
+++ b/lib/services/jenkins_provider.dart
@@ -16,13 +16,15 @@ class JenkinsProvider implements CiProvider {
   final String jobUrl;
   final String? username;
   final String? token;
+  final http.Client _client;
 
-  const JenkinsProvider({
+  JenkinsProvider({
     required this.label,
     required this.jobUrl,
     this.username,
     this.token,
-  });
+    http.Client? client,
+  }) : _client = client ?? http.Client();
 
   @override
   Future<CiRun> fetchLatestRun() async {
@@ -37,7 +39,7 @@ class JenkinsProvider implements CiProvider {
     }
 
     try {
-      final response = await http
+      final response = await _client
           .get(Uri.parse(url), headers: headers)
           .timeout(const Duration(seconds: 15));
 

--- a/lib/services/jenkins_provider.dart
+++ b/lib/services/jenkins_provider.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'ci_provider.dart';
+
+/// Fetches the latest build status for a Jenkins job.
+///
+/// Config keys (from workflows.yaml):
+///   provider: jenkins
+///   label:    "My Jenkins job"    # display name
+///   url:      https://jenkins.example.com/job/my-job
+///   username: admin               # optional; for authenticated Jenkins
+///   token:    abc123              # Jenkins API token
+class JenkinsProvider implements CiProvider {
+  @override
+  final String label;
+  final String jobUrl;
+  final String? username;
+  final String? token;
+
+  const JenkinsProvider({
+    required this.label,
+    required this.jobUrl,
+    this.username,
+    this.token,
+  });
+
+  @override
+  Future<CiRun> fetchLatestRun() async {
+    // Strip trailing slash so we can append /lastBuild/api/json cleanly.
+    final base = jobUrl.endsWith('/') ? jobUrl.substring(0, jobUrl.length - 1) : jobUrl;
+    final url = '$base/lastBuild/api/json';
+
+    final headers = <String, String>{};
+    if (username != null && token != null) {
+      final credentials = base64Encode(utf8.encode('$username:$token'));
+      headers['Authorization'] = 'Basic $credentials';
+    }
+
+    try {
+      final response = await http
+          .get(Uri.parse(url), headers: headers)
+          .timeout(const Duration(seconds: 15));
+
+      if (response.statusCode != 200) {
+        return CiRun(
+          label: label,
+          status: 'error',
+          fetchError: 'HTTP ${response.statusCode}',
+        );
+      }
+
+      final data = json.decode(response.body) as Map<String, dynamic>;
+
+      final building = data['building'] as bool? ?? false;
+      final result = data['result'] as String?; // 'SUCCESS' | 'FAILURE' | 'ABORTED' | 'UNSTABLE' | null
+
+      final String status;
+      if (building) {
+        status = 'in_progress';
+      } else {
+        status = switch (result) {
+          'SUCCESS' => 'success',
+          'FAILURE' => 'failure',
+          'ABORTED' => 'cancelled',
+          'UNSTABLE' => 'failure', // treat unstable as failure for visibility
+          _ => 'unknown',
+        };
+      }
+
+      DateTime? updatedAt;
+      final timestamp = data['timestamp'] as int?;
+      if (timestamp != null) {
+        updatedAt = DateTime.fromMillisecondsSinceEpoch(timestamp);
+      }
+
+      // Jenkins returns the full URL to the build in the 'url' field.
+      final runUrl = data['url'] as String?;
+
+      return CiRun(
+        label: label,
+        status: status,
+        updatedAt: updatedAt,
+        runUrl: runUrl,
+      );
+    } catch (e) {
+      return CiRun(label: label, status: 'error', fetchError: e.toString());
+    }
+  }
+}

--- a/lib/widgets/current_speaker.dart
+++ b/lib/widgets/current_speaker.dart
@@ -4,12 +4,14 @@ class CurrentSpeaker extends StatelessWidget {
   final int currentPersonIndex;
   final List<String> people;
   final bool showTeamMembersHeader;
+  final bool isDashboardMode;
 
   const CurrentSpeaker({
     super.key,
     required this.currentPersonIndex,
     required this.people,
     this.showTeamMembersHeader = false,
+    this.isDashboardMode = false,
   });
 
   @override
@@ -28,9 +30,11 @@ class CurrentSpeaker extends StatelessWidget {
           SizedBox(
             width: double.infinity,
             child: Text(
-              people.isNotEmpty
-                  ? people[currentPersonIndex]
-                  : 'Please add participants',
+              isDashboardMode && people.isNotEmpty
+                  ? 'Daily Standup'
+                  : (people.isNotEmpty
+                      ? people[currentPersonIndex]
+                      : 'Please add participants'),
               style: TextStyle(
                 fontSize: isNarrow ? 24 : 32,
                 fontWeight: FontWeight.w500,
@@ -43,11 +47,13 @@ class CurrentSpeaker extends StatelessWidget {
           ),
           SizedBox(height: isNarrow ? 6 : 8),
           Text(
-            (isNarrow && showTeamMembersHeader)
-                ? 'Team Members'
-                : (people.isNotEmpty
-                    ? 'Person ${currentPersonIndex + 1} of ${people.length}'
-                    : ''),
+            isDashboardMode && people.isNotEmpty
+                ? '${people.length} ${people.length == 1 ? 'participant' : 'participants'}'
+                : (isNarrow && showTeamMembersHeader)
+                    ? 'Team Members'
+                    : (people.isNotEmpty
+                        ? 'Person ${currentPersonIndex + 1} of ${people.length}'
+                        : ''),
             style: TextStyle(
               color: textSecondary,
               fontSize: isNarrow ? 14 : 16,

--- a/lib/widgets/timer_section.dart
+++ b/lib/widgets/timer_section.dart
@@ -6,7 +6,7 @@ import 'circular_timer.dart';
 import 'timer_controls.dart';
 import 'navigation_controls.dart';
 import 'celebration_screen.dart';
-import '../comic.dart';
+import '../screens/dashboard_screen.dart';
 
 class TimerSection extends StatefulWidget {
   final CountDownController controller;
@@ -105,6 +105,7 @@ class _TimerSectionState extends State<TimerSection> {
                 currentPersonIndex: widget.currentPersonIndex,
                 people: widget.people,
                 showTeamMembersHeader: widget.showTeamMembersHeader,
+                isDashboardMode: showComic,
               ),
               Container(
                 width: double.infinity,
@@ -119,7 +120,7 @@ class _TimerSectionState extends State<TimerSection> {
                           onResetTimer: _onResetFromCelebration,
                         )
                       : showComic
-                          ? ComicScreen(
+                          ? DashboardScreen(
                               showTimerControls: widget.people.isNotEmpty && timerInInitialState,
                               isRunning: widget.isRunning,
                               isDisabled: widget.people.isEmpty,

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <desktop_window/desktop_window_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 #include <window_size/window_size_plugin.h>
 #include <yaru_window_linux/yaru_window_linux_plugin.h>
@@ -23,6 +24,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
   g_autoptr(FlPluginRegistrar) window_manager_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
   window_manager_plugin_register_with_registrar(window_manager_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   desktop_window
   gtk
   screen_retriever_linux
+  url_launcher_linux
   window_manager
   window_size
   yaru_window_linux

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   circular_countdown_timer:
     dependency: "direct main"
     description:
@@ -296,14 +296,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -356,18 +348,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   matrix4_transform:
     dependency: transitive
     description:
@@ -713,26 +705,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.15"
   typed_data:
     dependency: transitive
     description:
@@ -741,6 +733,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.28"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
@@ -830,7 +886,7 @@ packages:
     source: hosted
     version: "6.6.1"
   yaml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
@@ -886,5 +942,5 @@ packages:
     source: hosted
     version: "0.0.4"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,8 @@ dependencies:
   shared_preferences: ^2.2.2
   flutter_riverpod: ^3.0.3
   confetti: ^0.8.0
+  yaml: ^3.1.2
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_test:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,6 @@ apps:
     extensions: [gnome]
     plugs:
       - network
-      - home
 
 parts:
   standup-timer:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,7 @@ apps:
     extensions: [gnome]
     plugs:
       - network
+      - home
 
 parts:
   standup-timer:

--- a/test/config_service_test.dart
+++ b/test/config_service_test.dart
@@ -1,0 +1,236 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:standup/services/config_service.dart';
+import 'package:standup/services/github_provider.dart';
+import 'package:standup/services/jenkins_provider.dart';
+
+void main() {
+  group('ConfigService.parseProviders', () {
+    group('GitHub entries', () {
+      test('parses a minimal GitHub entry', () {
+        final providers = ConfigService.parseProviders('''
+workflows:
+  - label: "Daily Builds"
+    provider: github
+    owner: canonical
+    repo: checkbox
+    workflow: daily.yaml
+''');
+        expect(providers, hasLength(1));
+        final p = providers[0] as GitHubProvider;
+        expect(p.label, 'Daily Builds');
+        expect(p.owner, 'canonical');
+        expect(p.repo, 'checkbox');
+        expect(p.workflow, 'daily.yaml');
+        expect(p.token, isNull);
+      });
+
+      test('label defaults to owner/repo when omitted', () {
+        final providers = ConfigService.parseProviders('''
+workflows:
+  - provider: github
+    owner: canonical
+    repo: checkbox
+    workflow: daily.yaml
+''');
+        expect(providers[0].label, 'canonical/checkbox');
+      });
+
+      test('per-entry token is used when present', () {
+        final providers = ConfigService.parseProviders('''
+workflows:
+  - provider: github
+    owner: canonical
+    repo: checkbox
+    workflow: daily.yaml
+    token: ghp_entry
+''');
+        expect((providers[0] as GitHubProvider).token, 'ghp_entry');
+      });
+
+      test('top-level github_token is applied when no per-entry token', () {
+        final providers = ConfigService.parseProviders('''
+github_token: ghp_default
+
+workflows:
+  - provider: github
+    owner: canonical
+    repo: checkbox
+    workflow: daily.yaml
+''');
+        expect((providers[0] as GitHubProvider).token, 'ghp_default');
+      });
+
+      test('per-entry token overrides top-level github_token', () {
+        final providers = ConfigService.parseProviders('''
+github_token: ghp_default
+
+workflows:
+  - provider: github
+    owner: canonical
+    repo: checkbox
+    workflow: daily.yaml
+    token: ghp_override
+''');
+        expect((providers[0] as GitHubProvider).token, 'ghp_override');
+      });
+
+      test('throws FormatException when owner is missing', () {
+        expect(
+          () => ConfigService.parseProviders('''
+workflows:
+  - label: "Bad"
+    provider: github
+    repo: checkbox
+    workflow: daily.yaml
+'''),
+          throwsA(isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('owner'),
+          )),
+        );
+      });
+
+      test('throws FormatException when repo is missing', () {
+        expect(
+          () => ConfigService.parseProviders('''
+workflows:
+  - provider: github
+    owner: canonical
+    workflow: daily.yaml
+'''),
+          throwsA(isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('repo'),
+          )),
+        );
+      });
+
+      test('throws FormatException when workflow is missing', () {
+        expect(
+          () => ConfigService.parseProviders('''
+workflows:
+  - provider: github
+    owner: canonical
+    repo: checkbox
+'''),
+          throwsA(isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('workflow'),
+          )),
+        );
+      });
+    });
+
+    group('Jenkins entries', () {
+      test('parses a minimal Jenkins entry', () {
+        final providers = ConfigService.parseProviders('''
+workflows:
+  - label: "Jenkins Job"
+    provider: jenkins
+    url: https://jenkins.example.com/job/my-job
+''');
+        expect(providers, hasLength(1));
+        final p = providers[0] as JenkinsProvider;
+        expect(p.label, 'Jenkins Job');
+        expect(p.jobUrl, 'https://jenkins.example.com/job/my-job');
+        expect(p.username, isNull);
+        expect(p.token, isNull);
+      });
+
+      test('label defaults to url when omitted', () {
+        final providers = ConfigService.parseProviders('''
+workflows:
+  - provider: jenkins
+    url: https://jenkins.example.com/job/my-job
+''');
+        expect(providers[0].label, 'https://jenkins.example.com/job/my-job');
+      });
+
+      test('parses Jenkins entry with credentials', () {
+        final providers = ConfigService.parseProviders('''
+workflows:
+  - provider: jenkins
+    label: "Secure Job"
+    url: https://jenkins.example.com/job/secure
+    username: admin
+    token: abc123
+''');
+        final p = providers[0] as JenkinsProvider;
+        expect(p.username, 'admin');
+        expect(p.token, 'abc123');
+      });
+
+      test('throws FormatException when url is missing', () {
+        expect(
+          () => ConfigService.parseProviders('''
+workflows:
+  - label: "Bad Jenkins"
+    provider: jenkins
+'''),
+          throwsA(isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('url'),
+          )),
+        );
+      });
+    });
+
+    group('mixed and edge cases', () {
+      test('parses multiple entries of different providers', () {
+        final providers = ConfigService.parseProviders('''
+workflows:
+  - label: "GH"
+    provider: github
+    owner: canonical
+    repo: checkbox
+    workflow: daily.yaml
+  - label: "Jenkins"
+    provider: jenkins
+    url: https://jenkins.example.com/job/x
+''');
+        expect(providers, hasLength(2));
+        expect(providers[0], isA<GitHubProvider>());
+        expect(providers[1], isA<JenkinsProvider>());
+      });
+
+      test('returns empty list when workflows key is absent', () {
+        final providers = ConfigService.parseProviders('github_token: ghp_x\n');
+        expect(providers, isEmpty);
+      });
+
+      test('returns empty list for empty workflows list', () {
+        final providers = ConfigService.parseProviders('workflows:\n');
+        expect(providers, isEmpty);
+      });
+
+      test('provider defaults to github when key is omitted', () {
+        final providers = ConfigService.parseProviders('''
+workflows:
+  - owner: canonical
+    repo: checkbox
+    workflow: daily.yaml
+''');
+        expect(providers[0], isA<GitHubProvider>());
+      });
+
+      test('throws FormatException for unknown provider', () {
+        expect(
+          () => ConfigService.parseProviders('''
+workflows:
+  - provider: circleci
+    label: "Bad"
+'''),
+          throwsA(isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('circleci'),
+          )),
+        );
+      });
+    });
+  });
+}

--- a/test/current_speaker_test.dart
+++ b/test/current_speaker_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:standup/widgets/current_speaker.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('CurrentSpeaker', () {
+    group('normal mode', () {
+      testWidgets('shows the current person name', (tester) async {
+        await tester.pumpWidget(_wrap(const CurrentSpeaker(
+          currentPersonIndex: 0,
+          people: ['Alice', 'Bob', 'Carol'],
+        )));
+        expect(find.text('Alice'), findsOneWidget);
+        expect(find.text('Person 1 of 3'), findsOneWidget);
+      });
+
+      testWidgets('shows the correct name for non-zero index', (tester) async {
+        await tester.pumpWidget(_wrap(const CurrentSpeaker(
+          currentPersonIndex: 2,
+          people: ['Alice', 'Bob', 'Carol'],
+        )));
+        expect(find.text('Carol'), findsOneWidget);
+        expect(find.text('Person 3 of 3'), findsOneWidget);
+      });
+
+      testWidgets('shows placeholder when people list is empty', (tester) async {
+        await tester.pumpWidget(_wrap(const CurrentSpeaker(
+          currentPersonIndex: 0,
+          people: [],
+        )));
+        expect(find.text('Please add participants'), findsOneWidget);
+        expect(find.text('Person 1 of 0'), findsNothing);
+      });
+    });
+
+    group('dashboard mode', () {
+      testWidgets('shows "Daily Standup" instead of person name', (tester) async {
+        await tester.pumpWidget(_wrap(const CurrentSpeaker(
+          currentPersonIndex: 0,
+          people: ['Alice', 'Bob', 'Carol'],
+          isDashboardMode: true,
+        )));
+        expect(find.text('Daily Standup'), findsOneWidget);
+        expect(find.text('Alice'), findsNothing);
+      });
+
+      testWidgets('shows plural participant count', (tester) async {
+        await tester.pumpWidget(_wrap(const CurrentSpeaker(
+          currentPersonIndex: 0,
+          people: ['Alice', 'Bob', 'Carol'],
+          isDashboardMode: true,
+        )));
+        expect(find.text('3 participants'), findsOneWidget);
+        expect(find.text('Person 1 of 3'), findsNothing);
+      });
+
+      testWidgets('shows singular participant count for one person', (tester) async {
+        await tester.pumpWidget(_wrap(const CurrentSpeaker(
+          currentPersonIndex: 0,
+          people: ['Alice'],
+          isDashboardMode: true,
+        )));
+        expect(find.text('1 participant'), findsOneWidget);
+        expect(find.text('1 participants'), findsNothing);
+      });
+
+      testWidgets('shows placeholder when people list is empty', (tester) async {
+        await tester.pumpWidget(_wrap(const CurrentSpeaker(
+          currentPersonIndex: 0,
+          people: [],
+          isDashboardMode: true,
+        )));
+        expect(find.text('Please add participants'), findsOneWidget);
+        expect(find.text('Daily Standup'), findsNothing);
+      });
+    });
+  });
+}

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -21,7 +21,7 @@ class _ErrorNotifier extends WorkflowsNotifier {
   @override
   WorkflowsState build() => const WorkflowsState(
         isLoading: false,
-        configError: 'Create ~/.config/standup-timer/workflows.yaml to monitor CI workflows.',
+        configError: 'Create workflows.yaml to monitor CI workflows.',
       );
 }
 
@@ -31,8 +31,14 @@ class _WithRunsNotifier extends WorkflowsNotifier {
         isLoading: false,
         lastFetched: DateTime.now(),
         runs: const [
-          CiRun(label: 'Checkbox Daily Builds', status: 'success', branch: 'main'),
-          CiRun(label: 'Release pipeline', status: 'failure', branch: 'release/1.0'),
+          CiRun(
+              label: 'Checkbox Daily Builds',
+              status: 'success',
+              branch: 'main'),
+          CiRun(
+              label: 'Release pipeline',
+              status: 'failure',
+              branch: 'release/1.0'),
           CiRun(label: 'Nightly job', status: 'in_progress'),
         ],
       );
@@ -60,7 +66,8 @@ void main() {
       });
 
       testWidgets('shown when onStartStandup is provided', (tester) async {
-        await tester.pumpWidget(_wrapEmpty(DashboardScreen(onStartStandup: () {})));
+        await tester
+            .pumpWidget(_wrapEmpty(DashboardScreen(onStartStandup: () {})));
         await tester.pumpAndSettle();
         expect(find.text('Start Standup'), findsOneWidget);
       });
@@ -74,7 +81,8 @@ void main() {
         expect(called, isTrue);
       });
 
-      testWidgets('tapping does not call the callback when isDisabled', (tester) async {
+      testWidgets('tapping does not call the callback when isDisabled',
+          (tester) async {
         var called = false;
         await tester.pumpWidget(_wrapEmpty(DashboardScreen(
           onStartStandup: () => called = true,
@@ -99,7 +107,8 @@ void main() {
         expect(find.byIcon(Icons.refresh), findsOneWidget);
       });
 
-      testWidgets('shows loading indicator instead of refresh button when loading',
+      testWidgets(
+          'shows loading indicator instead of refresh button when loading',
           (tester) async {
         await tester.pumpWidget(
             _wrap(const DashboardScreen(), notifier: _LoadingNotifier.new));
@@ -108,7 +117,8 @@ void main() {
         expect(find.byIcon(Icons.refresh), findsNothing);
       });
 
-      testWidgets('shows time-ago label when lastFetched is set', (tester) async {
+      testWidgets('shows time-ago label when lastFetched is set',
+          (tester) async {
         await tester.pumpWidget(
             _wrap(const DashboardScreen(), notifier: _WithRunsNotifier.new));
         await tester.pumpAndSettle();
@@ -123,8 +133,7 @@ void main() {
             _wrap(const DashboardScreen(), notifier: _ErrorNotifier.new));
         await tester.pumpAndSettle();
         expect(
-          find.textContaining(
-              'Create ~/.config/standup-timer/workflows.yaml'),
+          find.textContaining('Create ~/.config/standup-timer/workflows.yaml'),
           findsOneWidget,
         );
       });

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:standup/screens/dashboard_screen.dart';
+import 'package:standup/providers/workflows_provider.dart';
+
+// Returns a settled, empty state without touching the filesystem.
+class _FakeWorkflowsNotifier extends WorkflowsNotifier {
+  @override
+  WorkflowsState build() => const WorkflowsState(isLoading: false);
+}
+
+Widget _wrap(Widget child) => ProviderScope(
+      overrides: [
+        workflowsProvider.overrideWith(_FakeWorkflowsNotifier.new),
+      ],
+      child: MaterialApp(home: Scaffold(body: child)),
+    );
+
+void main() {
+  group('DashboardScreen', () {
+    testWidgets('does not show Start Standup button when onStartStandup is null',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const DashboardScreen()));
+      await tester.pumpAndSettle();
+      expect(find.text('Start Standup'), findsNothing);
+    });
+
+    testWidgets('shows Start Standup button when onStartStandup is provided',
+        (tester) async {
+      await tester.pumpWidget(_wrap(DashboardScreen(onStartStandup: () {})));
+      await tester.pumpAndSettle();
+      expect(find.text('Start Standup'), findsOneWidget);
+    });
+
+    testWidgets('tapping Start Standup calls the callback', (tester) async {
+      var called = false;
+      await tester.pumpWidget(_wrap(DashboardScreen(
+        onStartStandup: () => called = true,
+      )));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Start Standup'));
+      expect(called, isTrue);
+    });
+
+    testWidgets('tapping Start Standup when isDisabled does not call the callback',
+        (tester) async {
+      var called = false;
+      await tester.pumpWidget(_wrap(DashboardScreen(
+        onStartStandup: () => called = true,
+        isDisabled: true,
+      )));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Start Standup'));
+      expect(called, isFalse);
+    });
+  });
+}

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -133,7 +133,7 @@ void main() {
             _wrap(const DashboardScreen(), notifier: _ErrorNotifier.new));
         await tester.pumpAndSettle();
         expect(
-          find.textContaining('Create ~/.config/standup-timer/workflows.yaml'),
+          find.textContaining('Create workflows.yaml to monitor CI workflows.'),
           findsOneWidget,
         );
       });

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -3,56 +3,173 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:standup/screens/dashboard_screen.dart';
 import 'package:standup/providers/workflows_provider.dart';
+import 'package:standup/services/ci_provider.dart';
 
-// Returns a settled, empty state without touching the filesystem.
-class _FakeWorkflowsNotifier extends WorkflowsNotifier {
+// ── Fake notifiers ────────────────────────────────────────────────────────────
+
+class _EmptyNotifier extends WorkflowsNotifier {
   @override
   WorkflowsState build() => const WorkflowsState(isLoading: false);
 }
 
-Widget _wrap(Widget child) => ProviderScope(
-      overrides: [
-        workflowsProvider.overrideWith(_FakeWorkflowsNotifier.new),
-      ],
+class _LoadingNotifier extends WorkflowsNotifier {
+  @override
+  WorkflowsState build() => const WorkflowsState(isLoading: true);
+}
+
+class _ErrorNotifier extends WorkflowsNotifier {
+  @override
+  WorkflowsState build() => const WorkflowsState(
+        isLoading: false,
+        configError: 'Create ~/.config/standup-timer/workflows.yaml to monitor CI workflows.',
+      );
+}
+
+class _WithRunsNotifier extends WorkflowsNotifier {
+  @override
+  WorkflowsState build() => WorkflowsState(
+        isLoading: false,
+        lastFetched: DateTime.now(),
+        runs: const [
+          CiRun(label: 'Checkbox Daily Builds', status: 'success', branch: 'main'),
+          CiRun(label: 'Release pipeline', status: 'failure', branch: 'release/1.0'),
+          CiRun(label: 'Nightly job', status: 'in_progress'),
+        ],
+      );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+Widget _wrap(Widget child, {required WorkflowsNotifier Function() notifier}) =>
+    ProviderScope(
+      overrides: [workflowsProvider.overrideWith(notifier)],
       child: MaterialApp(home: Scaffold(body: child)),
     );
 
+Widget _wrapEmpty(Widget child) => _wrap(child, notifier: _EmptyNotifier.new);
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
 void main() {
   group('DashboardScreen', () {
-    testWidgets('does not show Start Standup button when onStartStandup is null',
-        (tester) async {
-      await tester.pumpWidget(_wrap(const DashboardScreen()));
-      await tester.pumpAndSettle();
-      expect(find.text('Start Standup'), findsNothing);
+    group('Start Standup button', () {
+      testWidgets('not shown when onStartStandup is null', (tester) async {
+        await tester.pumpWidget(_wrapEmpty(const DashboardScreen()));
+        await tester.pumpAndSettle();
+        expect(find.text('Start Standup'), findsNothing);
+      });
+
+      testWidgets('shown when onStartStandup is provided', (tester) async {
+        await tester.pumpWidget(_wrapEmpty(DashboardScreen(onStartStandup: () {})));
+        await tester.pumpAndSettle();
+        expect(find.text('Start Standup'), findsOneWidget);
+      });
+
+      testWidgets('tapping calls the callback when enabled', (tester) async {
+        var called = false;
+        await tester.pumpWidget(
+            _wrapEmpty(DashboardScreen(onStartStandup: () => called = true)));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Start Standup'));
+        expect(called, isTrue);
+      });
+
+      testWidgets('tapping does not call the callback when isDisabled', (tester) async {
+        var called = false;
+        await tester.pumpWidget(_wrapEmpty(DashboardScreen(
+          onStartStandup: () => called = true,
+          isDisabled: true,
+        )));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Start Standup'));
+        expect(called, isFalse);
+      });
     });
 
-    testWidgets('shows Start Standup button when onStartStandup is provided',
-        (tester) async {
-      await tester.pumpWidget(_wrap(DashboardScreen(onStartStandup: () {})));
-      await tester.pumpAndSettle();
-      expect(find.text('Start Standup'), findsOneWidget);
+    group('header', () {
+      testWidgets('shows CI Status title', (tester) async {
+        await tester.pumpWidget(_wrapEmpty(const DashboardScreen()));
+        await tester.pumpAndSettle();
+        expect(find.text('CI Status'), findsOneWidget);
+      });
+
+      testWidgets('shows refresh button when not loading', (tester) async {
+        await tester.pumpWidget(_wrapEmpty(const DashboardScreen()));
+        await tester.pumpAndSettle();
+        expect(find.byIcon(Icons.refresh), findsOneWidget);
+      });
+
+      testWidgets('shows loading indicator instead of refresh button when loading',
+          (tester) async {
+        await tester.pumpWidget(
+            _wrap(const DashboardScreen(), notifier: _LoadingNotifier.new));
+        await tester.pump(); // single frame — don't settle (loading never ends)
+        expect(find.byType(CircularProgressIndicator), findsAtLeastNWidgets(1));
+        expect(find.byIcon(Icons.refresh), findsNothing);
+      });
+
+      testWidgets('shows time-ago label when lastFetched is set', (tester) async {
+        await tester.pumpWidget(
+            _wrap(const DashboardScreen(), notifier: _WithRunsNotifier.new));
+        await tester.pumpAndSettle();
+        // lastFetched is DateTime.now() so the label should be 'just now'
+        expect(find.text('just now'), findsOneWidget);
+      });
     });
 
-    testWidgets('tapping Start Standup calls the callback', (tester) async {
-      var called = false;
-      await tester.pumpWidget(_wrap(DashboardScreen(
-        onStartStandup: () => called = true,
-      )));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Start Standup'));
-      expect(called, isTrue);
+    group('body — config error state', () {
+      testWidgets('shows config error message', (tester) async {
+        await tester.pumpWidget(
+            _wrap(const DashboardScreen(), notifier: _ErrorNotifier.new));
+        await tester.pumpAndSettle();
+        expect(
+          find.textContaining(
+              'Create ~/.config/standup-timer/workflows.yaml'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows settings icon in error state', (tester) async {
+        await tester.pumpWidget(
+            _wrap(const DashboardScreen(), notifier: _ErrorNotifier.new));
+        await tester.pumpAndSettle();
+        expect(find.byIcon(Icons.settings_outlined), findsOneWidget);
+      });
+
+      testWidgets('shows config file hint snippet', (tester) async {
+        await tester.pumpWidget(
+            _wrap(const DashboardScreen(), notifier: _ErrorNotifier.new));
+        await tester.pumpAndSettle();
+        expect(find.textContaining('workflows:'), findsOneWidget);
+      });
     });
 
-    testWidgets('tapping Start Standup when isDisabled does not call the callback',
-        (tester) async {
-      var called = false;
-      await tester.pumpWidget(_wrap(DashboardScreen(
-        onStartStandup: () => called = true,
-        isDisabled: true,
-      )));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Start Standup'));
-      expect(called, isFalse);
+    group('body — runs list', () {
+      testWidgets('shows run labels', (tester) async {
+        await tester.pumpWidget(
+            _wrap(const DashboardScreen(), notifier: _WithRunsNotifier.new));
+        await tester.pumpAndSettle();
+        expect(find.text('Checkbox Daily Builds'), findsOneWidget);
+        expect(find.text('Release pipeline'), findsOneWidget);
+        expect(find.text('Nightly job'), findsOneWidget);
+      });
+
+      testWidgets('shows run branch names', (tester) async {
+        await tester.pumpWidget(
+            _wrap(const DashboardScreen(), notifier: _WithRunsNotifier.new));
+        await tester.pumpAndSettle();
+        expect(find.text('main'), findsOneWidget);
+        expect(find.text('release/1.0'), findsOneWidget);
+      });
+
+      testWidgets('shows status badge labels', (tester) async {
+        await tester.pumpWidget(
+            _wrap(const DashboardScreen(), notifier: _WithRunsNotifier.new));
+        await tester.pumpAndSettle();
+        expect(find.text('success'), findsOneWidget);
+        expect(find.text('failure'), findsOneWidget);
+        expect(find.text('running'), findsOneWidget);
+      });
     });
   });
 }

--- a/test/github_provider_test.dart
+++ b/test/github_provider_test.dart
@@ -1,0 +1,214 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:standup/services/github_provider.dart';
+
+http.Response _json(Object body, {int status = 200}) =>
+    http.Response(json.encode(body), status,
+        headers: {'content-type': 'application/json'});
+
+Map<String, dynamic> _run({
+  String status = 'completed',
+  String? conclusion = 'success',
+  String branch = 'main',
+  String updatedAt = '2024-01-15T10:00:00Z',
+  String htmlUrl = 'https://github.com/canonical/checkbox/actions/runs/1',
+}) =>
+    {
+      'status': status,
+      'conclusion': conclusion,
+      'head_branch': branch,
+      'updated_at': updatedAt,
+      'html_url': htmlUrl,
+    };
+
+GitHubProvider _provider({String? token, required http.Client client}) =>
+    GitHubProvider(
+      label: 'Test Workflow',
+      owner: 'canonical',
+      repo: 'checkbox',
+      workflow: 'daily.yaml',
+      token: token,
+      client: client,
+    );
+
+void main() {
+  group('GitHubProvider.fetchLatestRun', () {
+    group('status mapping', () {
+      test('completed/success → success', () async {
+        final p = _provider(
+          client: MockClient((_) async =>
+              _json({'workflow_runs': [_run(conclusion: 'success')]})),
+        );
+        final run = await p.fetchLatestRun();
+        expect(run.status, 'success');
+      });
+
+      test('completed/failure → failure', () async {
+        final p = _provider(
+          client: MockClient((_) async =>
+              _json({'workflow_runs': [_run(conclusion: 'failure')]})),
+        );
+        expect((await p.fetchLatestRun()).status, 'failure');
+      });
+
+      test('completed/cancelled → cancelled', () async {
+        final p = _provider(
+          client: MockClient((_) async =>
+              _json({'workflow_runs': [_run(conclusion: 'cancelled')]})),
+        );
+        expect((await p.fetchLatestRun()).status, 'cancelled');
+      });
+
+      test('in_progress (not completed) → in_progress', () async {
+        final p = _provider(
+          client: MockClient((_) async => _json({
+                'workflow_runs': [
+                  _run(status: 'in_progress', conclusion: null)
+                ]
+              })),
+        );
+        expect((await p.fetchLatestRun()).status, 'in_progress');
+      });
+
+      test('queued → queued', () async {
+        final p = _provider(
+          client: MockClient((_) async => _json({
+                'workflow_runs': [_run(status: 'queued', conclusion: null)]
+              })),
+        );
+        expect((await p.fetchLatestRun()).status, 'queued');
+      });
+
+      test('empty runs list → unknown', () async {
+        final p = _provider(
+          client: MockClient(
+              (_) async => _json({'workflow_runs': <dynamic>[]})),
+        );
+        expect((await p.fetchLatestRun()).status, 'unknown');
+      });
+    });
+
+    group('field parsing', () {
+      test('populates label, branch, updatedAt, runUrl', () async {
+        final p = _provider(
+          client: MockClient((_) async => _json({
+                'workflow_runs': [
+                  _run(
+                    branch: 'release/1.0',
+                    updatedAt: '2024-03-20T12:34:56Z',
+                    htmlUrl: 'https://github.com/runs/42',
+                  )
+                ]
+              })),
+        );
+        final run = await p.fetchLatestRun();
+        expect(run.label, 'Test Workflow');
+        expect(run.branch, 'release/1.0');
+        expect(run.updatedAt, DateTime.parse('2024-03-20T12:34:56Z'));
+        expect(run.runUrl, 'https://github.com/runs/42');
+      });
+
+      test('null updated_at leaves updatedAt null', () async {
+        final runData = _run()..['updated_at'] = null;
+        // rebuild without updated_at key
+        final data = Map<String, dynamic>.from(runData);
+        data.remove('updated_at');
+        final p = _provider(
+          client: MockClient(
+              (_) async => _json({'workflow_runs': [data]})),
+        );
+        expect((await p.fetchLatestRun()).updatedAt, isNull);
+      });
+    });
+
+    group('HTTP errors', () {
+      test('HTTP 401 → status error with fetchError', () async {
+        final p = _provider(
+          client: MockClient((_) async => http.Response('Unauthorized', 401)),
+        );
+        final run = await p.fetchLatestRun();
+        expect(run.status, 'error');
+        expect(run.fetchError, contains('401'));
+      });
+
+      test('HTTP 404 → status error', () async {
+        final p = _provider(
+          client: MockClient((_) async => http.Response('Not Found', 404)),
+        );
+        expect((await p.fetchLatestRun()).status, 'error');
+      });
+
+      test('network exception → status error with message', () async {
+        final p = _provider(
+          client: MockClient((_) async => throw Exception('no network')),
+        );
+        final run = await p.fetchLatestRun();
+        expect(run.status, 'error');
+        expect(run.fetchError, contains('no network'));
+      });
+    });
+
+    group('authentication', () {
+      test('adds Authorization header when token is set', () async {
+        http.Request? captured;
+        final p = _provider(
+          token: 'ghp_secret',
+          client: MockClient((req) async {
+            captured = req;
+            return _json({'workflow_runs': [_run()]});
+          }),
+        );
+        await p.fetchLatestRun();
+        expect(captured!.headers['Authorization'], 'Bearer ghp_secret');
+      });
+
+      test('omits Authorization header when token is null', () async {
+        http.Request? captured;
+        final p = _provider(
+          client: MockClient((req) async {
+            captured = req;
+            return _json({'workflow_runs': [_run()]});
+          }),
+        );
+        await p.fetchLatestRun();
+        expect(captured!.headers.containsKey('Authorization'), isFalse);
+      });
+
+      test('sends correct Accept and API version headers', () async {
+        http.Request? captured;
+        final p = _provider(
+          client: MockClient((req) async {
+            captured = req;
+            return _json({'workflow_runs': [_run()]});
+          }),
+        );
+        await p.fetchLatestRun();
+        expect(captured!.headers['Accept'],
+            'application/vnd.github+json');
+        expect(
+            captured!.headers['X-GitHub-Api-Version'], '2022-11-28');
+      });
+    });
+
+    group('URL construction', () {
+      test('requests the correct API endpoint', () async {
+        Uri? requestedUrl;
+        final p = _provider(
+          client: MockClient((req) async {
+            requestedUrl = req.url;
+            return _json({'workflow_runs': [_run()]});
+          }),
+        );
+        await p.fetchLatestRun();
+        expect(
+          requestedUrl.toString(),
+          'https://api.github.com/repos/canonical/checkbox'
+          '/actions/workflows/daily.yaml/runs?per_page=1',
+        );
+      });
+    });
+  });
+}

--- a/test/jenkins_provider_test.dart
+++ b/test/jenkins_provider_test.dart
@@ -1,0 +1,222 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:standup/services/jenkins_provider.dart';
+
+http.Response _json(Object body, {int status = 200}) =>
+    http.Response(json.encode(body), status,
+        headers: {'content-type': 'application/json'});
+
+Map<String, dynamic> _build({
+  bool building = false,
+  String? result = 'SUCCESS',
+  int? timestamp = 1705312800000, // 2024-01-15T10:00:00Z in ms
+  String? url = 'https://jenkins.example.com/job/my-job/42/',
+}) =>
+    {
+      'building': building,
+      'result': result,
+      'timestamp': timestamp,
+      'url': url,
+    };
+
+JenkinsProvider _provider({
+  String jobUrl = 'https://jenkins.example.com/job/my-job',
+  String? username,
+  String? token,
+  required http.Client client,
+}) =>
+    JenkinsProvider(
+      label: 'Test Job',
+      jobUrl: jobUrl,
+      username: username,
+      token: token,
+      client: client,
+    );
+
+void main() {
+  group('JenkinsProvider.fetchLatestRun', () {
+    group('status mapping', () {
+      test('SUCCESS → success', () async {
+        final p = _provider(
+          client: MockClient(
+              (_) async => _json(_build(result: 'SUCCESS'))),
+        );
+        expect((await p.fetchLatestRun()).status, 'success');
+      });
+
+      test('FAILURE → failure', () async {
+        final p = _provider(
+          client: MockClient(
+              (_) async => _json(_build(result: 'FAILURE'))),
+        );
+        expect((await p.fetchLatestRun()).status, 'failure');
+      });
+
+      test('ABORTED → cancelled', () async {
+        final p = _provider(
+          client: MockClient(
+              (_) async => _json(_build(result: 'ABORTED'))),
+        );
+        expect((await p.fetchLatestRun()).status, 'cancelled');
+      });
+
+      test('UNSTABLE → failure', () async {
+        final p = _provider(
+          client: MockClient(
+              (_) async => _json(_build(result: 'UNSTABLE'))),
+        );
+        expect((await p.fetchLatestRun()).status, 'failure');
+      });
+
+      test('null result → unknown', () async {
+        final p = _provider(
+          client: MockClient(
+              (_) async => _json(_build(result: null))),
+        );
+        expect((await p.fetchLatestRun()).status, 'unknown');
+      });
+
+      test('building: true → in_progress regardless of result', () async {
+        final p = _provider(
+          client: MockClient(
+              (_) async => _json(_build(building: true, result: 'SUCCESS'))),
+        );
+        expect((await p.fetchLatestRun()).status, 'in_progress');
+      });
+    });
+
+    group('field parsing', () {
+      test('populates label, updatedAt, runUrl', () async {
+        final p = _provider(
+          client: MockClient((_) async => _json(_build(
+                timestamp: 1705312800000,
+                url: 'https://jenkins.example.com/job/my-job/42/',
+              ))),
+        );
+        final run = await p.fetchLatestRun();
+        expect(run.label, 'Test Job');
+        expect(run.updatedAt,
+            DateTime.fromMillisecondsSinceEpoch(1705312800000));
+        expect(run.runUrl, 'https://jenkins.example.com/job/my-job/42/');
+      });
+
+      test('null timestamp leaves updatedAt null', () async {
+        final p = _provider(
+          client: MockClient(
+              (_) async => _json(_build(timestamp: null))),
+        );
+        expect((await p.fetchLatestRun()).updatedAt, isNull);
+      });
+
+      test('branch is always null (Jenkins has no branch concept here)', () async {
+        final p = _provider(
+          client: MockClient((_) async => _json(_build())),
+        );
+        expect((await p.fetchLatestRun()).branch, isNull);
+      });
+    });
+
+    group('HTTP errors', () {
+      test('HTTP 500 → status error with fetchError', () async {
+        final p = _provider(
+          client: MockClient(
+              (_) async => http.Response('Server Error', 500)),
+        );
+        final run = await p.fetchLatestRun();
+        expect(run.status, 'error');
+        expect(run.fetchError, contains('500'));
+      });
+
+      test('HTTP 403 → status error', () async {
+        final p = _provider(
+          client: MockClient((_) async => http.Response('Forbidden', 403)),
+        );
+        expect((await p.fetchLatestRun()).status, 'error');
+      });
+
+      test('network exception → status error with message', () async {
+        final p = _provider(
+          client: MockClient((_) async => throw Exception('connection refused')),
+        );
+        final run = await p.fetchLatestRun();
+        expect(run.status, 'error');
+        expect(run.fetchError, contains('connection refused'));
+      });
+    });
+
+    group('URL construction', () {
+      test('appends /lastBuild/api/json to the job URL', () async {
+        Uri? requestedUrl;
+        final p = _provider(
+          client: MockClient((req) async {
+            requestedUrl = req.url;
+            return _json(_build());
+          }),
+        );
+        await p.fetchLatestRun();
+        expect(requestedUrl.toString(),
+            'https://jenkins.example.com/job/my-job/lastBuild/api/json');
+      });
+
+      test('strips trailing slash before appending path', () async {
+        Uri? requestedUrl;
+        final p = _provider(
+          jobUrl: 'https://jenkins.example.com/job/my-job/',
+          client: MockClient((req) async {
+            requestedUrl = req.url;
+            return _json(_build());
+          }),
+        );
+        await p.fetchLatestRun();
+        expect(requestedUrl.toString(),
+            'https://jenkins.example.com/job/my-job/lastBuild/api/json');
+      });
+    });
+
+    group('authentication', () {
+      test('adds Basic auth header when username and token are set', () async {
+        http.Request? captured;
+        final p = _provider(
+          username: 'admin',
+          token: 'abc123',
+          client: MockClient((req) async {
+            captured = req;
+            return _json(_build());
+          }),
+        );
+        await p.fetchLatestRun();
+        final expected =
+            'Basic ${base64Encode(utf8.encode('admin:abc123'))}';
+        expect(captured!.headers['Authorization'], expected);
+      });
+
+      test('omits Authorization header when credentials are absent', () async {
+        http.Request? captured;
+        final p = _provider(
+          client: MockClient((req) async {
+            captured = req;
+            return _json(_build());
+          }),
+        );
+        await p.fetchLatestRun();
+        expect(captured!.headers.containsKey('Authorization'), isFalse);
+      });
+
+      test('omits Authorization header when only username is set', () async {
+        http.Request? captured;
+        final p = _provider(
+          username: 'admin',
+          client: MockClient((req) async {
+            captured = req;
+            return _json(_build());
+          }),
+        );
+        await p.fetchLatestRun();
+        expect(captured!.headers.containsKey('Authorization'), isFalse);
+      });
+    });
+  });
+}

--- a/test/timer_section_test.dart
+++ b/test/timer_section_test.dart
@@ -1,0 +1,132 @@
+import 'package:circular_countdown_timer/circular_countdown_timer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:standup/comic.dart';
+import 'package:standup/providers/workflows_provider.dart';
+import 'package:standup/screens/dashboard_screen.dart';
+import 'package:standup/widgets/timer_section.dart';
+
+// Settled, no-op provider override so DashboardScreen builds without
+// touching the filesystem.
+class _FakeWorkflowsNotifier extends WorkflowsNotifier {
+  @override
+  WorkflowsState build() => const WorkflowsState(isLoading: false);
+}
+
+Widget _wrap(Widget child) => ProviderScope(
+      overrides: [workflowsProvider.overrideWith(_FakeWorkflowsNotifier.new)],
+      child: MaterialApp(home: Scaffold(body: child)),
+    );
+
+// Builds a TimerSection with sensible defaults; only override what matters.
+TimerSection _section({
+  List<String> people = const [],
+  int currentPersonIndex = 0,
+  bool isRunning = false,
+  int duration = 120,
+  int? currentTime,
+}) =>
+    TimerSection(
+      controller: CountDownController(),
+      duration: duration,
+      isRunning: isRunning,
+      currentPersonIndex: currentPersonIndex,
+      people: people,
+      currentTime: currentTime ?? duration,
+      onToggleTimer: () {},
+      onResetTimer: () {},
+      onPreviousPerson: () {},
+      onNextPerson: () {},
+      onPersonSelected: (_) {},
+      onTimerComplete: () {},
+    );
+
+void main() {
+  group('TimerSection pre-start flow', () {
+    testWidgets('shows ComicScreen in initial state with no participants',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      await tester.pumpWidget(_wrap(_section()));
+      await tester.pump();
+      expect(find.byType(ComicScreen), findsOneWidget);
+      expect(find.byType(DashboardScreen), findsNothing);
+    });
+
+    testWidgets('shows ComicScreen in initial state with participants',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      await tester.pumpWidget(_wrap(_section(people: ['Alice', 'Bob'])));
+      await tester.pump();
+      expect(find.byType(ComicScreen), findsOneWidget);
+      expect(find.byType(DashboardScreen), findsNothing);
+    });
+
+    testWidgets('shows timer UI (not ComicScreen) when timer is running',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      await tester.pumpWidget(_wrap(_section(
+        people: ['Alice', 'Bob'],
+        isRunning: true,
+        currentTime: 60, // mid-run
+      )));
+      await tester.pump();
+      expect(find.byType(ComicScreen), findsNothing);
+      expect(find.byType(DashboardScreen), findsNothing);
+    });
+
+    testWidgets('shows ComicScreen again after timer returns to initial state',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+
+      // Pump with timer running (non-initial state).
+      await tester.pumpWidget(_wrap(_section(
+        people: ['Alice', 'Bob'],
+        isRunning: true,
+        currentTime: 60,
+      )));
+      await tester.pump();
+      expect(find.byType(ComicScreen), findsNothing);
+
+      // Reset to initial state.
+      await tester.pumpWidget(_wrap(_section(
+        people: ['Alice', 'Bob'],
+        isRunning: false,
+        currentTime: 120, // back to full duration
+      )));
+      await tester.pump();
+      expect(find.byType(ComicScreen), findsOneWidget);
+    });
+  });
+
+  group('TimerSection header', () {
+    testWidgets('shows "Daily Standup" title in pre-start state', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      await tester.pumpWidget(
+          _wrap(_section(people: ['Alice', 'Bob', 'Carol'])));
+      await tester.pump();
+      expect(find.text('Daily Standup'), findsOneWidget);
+      expect(find.text('Alice'), findsNothing);
+    });
+
+    testWidgets('shows participant count in pre-start state', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      await tester.pumpWidget(
+          _wrap(_section(people: ['Alice', 'Bob', 'Carol'])));
+      await tester.pump();
+      expect(find.text('3 participants'), findsOneWidget);
+    });
+
+    testWidgets('shows current person name while timer is running', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      await tester.pumpWidget(_wrap(_section(
+        people: ['Alice', 'Bob'],
+        isRunning: true,
+        currentTime: 60,
+      )));
+      await tester.pump();
+      expect(find.text('Alice'), findsOneWidget);
+      expect(find.text('Daily Standup'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds a CI dashboard page, used to monitor together every morning the status of important workflows.

Supports:
- github (including private repos)
- jenkins

Disclaimer: claude is my friend.

<img width="781" height="345" alt="image" src="https://github.com/user-attachments/assets/e8d70680-05d2-40c6-a752-7faccbfb2f05" />

